### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license-file = "LICENSE"
 keywords = ["uuid", "base64", "url-safe", "short", "mini"]
 categories = ["data-structures"]
 readme = "README.md"
-homepage = "https://github.com/nanokeshtw/mini_uuid"
+repository = "https://github.com/nanokeshtw/mini_uuid"
 documentation = "https://docs.rs/mini_uuid/latest/mini_uuid/"
 
 [dependencies]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.